### PR TITLE
[fix] Error "Must have { required: true } when using `isTitle`"

### DIFF
--- a/.tina/config.ts
+++ b/.tina/config.ts
@@ -31,7 +31,8 @@ export default defineStaticConfig({
             name: "title",
             label: "Title",
             isTitle: true,
-          },{
+            required: true,
+          },
             type: "string",
             name: "description",
             label: "Description",


### PR DESCRIPTION
Hey thanks for sharing this repo. I found an easily fixable error after installing it.